### PR TITLE
Add Bluesky profile link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -24,6 +24,7 @@ disqusShortname = "gempir-com"
   linkedin = "daniel-pasch-sannapiu-593662161"
   xing = "Daniel_PaschSannapiu"
   twitter = "gempir"
+  bluesky = "gempir.com"
 
 ## Main Menu
 [[menu.main]]

--- a/themes/simple/layouts/index.html
+++ b/themes/simple/layouts/index.html
@@ -33,6 +33,9 @@
         {{ with .Site.Params.social.twitter }}
         <a href="https://www.twitter.com/{{.}}" class="social-icon"><i class="fab fa-twitter" aria-hidden="true"></i></a>
         {{ end }}
+        {{ with .Site.Params.social.bluesky }}
+        <a href="https://bsky.app/profile/{{.}}" class="social-icon"><i class="fab fa-bluesky" aria-hidden="true"></i></a>
+        {{ end }}
     </section>
 </div>
 {{end}}

--- a/themes/simple/layouts/partials/_shared/head.html
+++ b/themes/simple/layouts/partials/_shared/head.html
@@ -10,8 +10,8 @@
 	<meta name="description" content="{{ . }}">{{ end }}
 	{{ with .Site.Params.meta.keywords }}
 	<meta name="keywords" content="{{ . }}">{{ end }}
-	<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" integrity="sha384-DNOHZ68U8hZfKXOrtjWvjxusGo9WQnrNx2sqG0tfsghAvtVlRW3tvkXWZh58N9jp"
-	 crossorigin="anonymous">
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.7.2/css/all.min.css" integrity="sha384-nRgPTkuX86pH8yjPJUAFuASXQSSl2/bBUiNV47vSYpKFxHJhbcrGnmlYpYJMeD7a"
+         crossorigin="anonymous">
 	<link href="https://fonts.googleapis.com/css?family=Righteous%7CMerriweather:300,300i,400,400i,700,700i" rel="stylesheet">
 	<link href="https://fonts.googleapis.com/css?family=Roboto+Mono" rel="stylesheet">
 	{{ $styles := resources.Get "scss/main.scss" | toCSS | minify | fingerprint }}

--- a/themes/simple/layouts/partials/list-partials/postbox.html
+++ b/themes/simple/layouts/partials/list-partials/postbox.html
@@ -1,7 +1,7 @@
 <!-- begin post -->
 <a class="post" href="{{ .Permalink }}">
     <!-- <div class="maxthumb">
-        <a href="{{ .URL }}">
+        <a href="{{ .Permalink }}">
             {{with .Params.image}}
             <img class="img-fluid" src="{{ . | urlize | relURL }}" alt="A thumbnail image">
             {{end}}


### PR DESCRIPTION
## Summary
- add Bluesky handle to site configuration and homepage
- upgrade Font Awesome to 6.7.2 for Bluesky icon support
- fix Hugo list partial to use `.Permalink`

## Testing
- `hugo --minify`


------
https://chatgpt.com/codex/tasks/task_e_68c7da62eb3c832e990358c114cc4b6a